### PR TITLE
Fix for better compat with Replace Stuff

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# top-most EditorConfig file
+root = true
+
+# 4 space indentation
+[*.{cs,xml}]
+indent_style = space
+indent_size = 4

--- a/Source/1.3/SmarterConstruction/Core/ClosedRegionDetector.cs
+++ b/Source/1.3/SmarterConstruction/Core/ClosedRegionDetector.cs
@@ -68,7 +68,11 @@ namespace SmarterConstruction.Core
         private static HashSet<IntVec3> FloodFill(IPathGrid pathGrid, IntVec3 start, HashSet<IntVec3> addedBlockers)
         {
             var region = new HashSet<IntVec3>();
-            if (!pathGrid.Walkable(start)) return region;
+            if (!pathGrid.Walkable(start))
+            {
+                region.Add(start);//Treat an unwalkable adjacent cell as its own region, just to check it
+                return region;
+            }
 
             var queuedPositions = new Queue<IntVec3>();
             queuedPositions.Enqueue(start);


### PR DESCRIPTION
This change simply adds any single unwalkable adjacent cell to the checklist for enclosure, just in case.

With this, the ReplaceStuff mod can build a room with walls into mountain rock, without the corner rock being inaccessible - unmined and unbuilt.

The conflict was - Since ReplaceStuff allows the wall blueprint over the rock, there is no 'region' under the blueprint, so SmarterConstruction didn't have a region to check for blockage. All it needed was to check the single adjacent cell, even if unwalkable, for possibly blocked things, then ReplaceStuff's blueprints are checked for blockage as usual.


(Thinking about this more in the future, this mod could probably check adjacent designations like mining and uninstalling that it would block. But that's a bigger change.)